### PR TITLE
스크롤리텔링 추가, 스타일 변경, 오작동 수정, 성능 개선

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,11 +83,10 @@
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
         >
-          <rect x="3.5" y="3.5" width="39" height="41" stroke="#ffffff88" />
-          <rect x="0.5" y="0.5" width="39" height="41" stroke="#ffffff99" />
+          <rect x="3.5" y="3.5" width="39" height="41" />
+          <rect x="0.5" y="0.5" width="39" height="41" />
           <path
             d="M13.6751 31V13.5455H14.7404V21.7699H25.2575V13.5455H26.3228V31H25.2575V22.7585H14.7404V31H13.6751Z"
-            fill="#ffffff99"
           />
         </svg>
       </div>

--- a/index.html
+++ b/index.html
@@ -112,7 +112,7 @@
           <p>C: 모드 변경</p>
           <p>Enter: 선택</p>
         </div>
-        <button class="about__nav focusable">See Work</button>
+        <button class="about__nav focusable" data-text="See Work"></button>
       </div>
       <img
         src="./public/img/about-2.png"
@@ -132,7 +132,6 @@
       <div class="project-content"></div>
       <p class="project__describe"></p>
     </section>
-    <section id="contact"></section>
 
     <!-- 푸터 -->
     <footer>

--- a/index.html
+++ b/index.html
@@ -135,10 +135,6 @@
 
     <!-- 푸터 -->
     <footer>
-      <div class="copyright">
-        <ruby class="copyright__text"><rb>Hamelln</rb><rt>2023</rt></ruby
-        ><sup>ⓒ</sup>
-      </div>
       <div id="contact">
         <ul>
           <li>

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -273,7 +273,7 @@ rect {
   position: sticky;
   top: 20vh;
   left: 0;
-  width: 20%;
+  width: 14em;
   height: 100vh;
   display: flex;
   flex-direction: column;
@@ -493,6 +493,19 @@ rect {
   color: var(--text-color);
   font-size: var(--font-size-l);
   transition: background-color 0.45s ease, color 0.45s ease;
+  border-radius: 10px;
+}
+
+.mode__setting:focus,
+.mode__mute:focus,
+.mode__theme:focus {
+  outline: 1px solid var(--text-color);
+}
+
+.mode__setting:hover,
+.mode__mute:hover,
+.mode__theme:hover {
+  border: 1px solid var(--text-color);
 }
 
 .mode__theme.focusable {
@@ -791,7 +804,7 @@ rect {
 
 #project {
   width: 100%;
-  height: calc(100vh - 60px);
+  height: calc(100vh);
   transition: opacity 1s, transform 1s;
   opacity: 1;
   transform: translateX(0);
@@ -1173,11 +1186,16 @@ rect {
   column-gap: 20px;
 }
 
+#contact ul li {
+  box-sizing: border-box;
+}
+
 #contact a {
   display: flex;
   align-items: center;
   text-decoration: none;
   padding: 5px;
+  border: 1px solid transparent;
 }
 
 #contact img {
@@ -1188,6 +1206,13 @@ rect {
 #contact a:hover,
 #contact a:focus {
   animation: pulse 0.3s ease-in-out;
+}
+
+#contact a:focus {
+  outline: 1px solid var(--text-color);
+}
+#contact a:hover {
+  border: 1px solid var(--text-color);
 }
 
 @keyframes pulse {

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -8,6 +8,7 @@
   --font-size-m: 18px;
   --font-size-l: 20px;
   --font-size-xl: 24px;
+  --title-size-xxl: 40px;
   --title-size-xl: 32px;
   --title-size-l: 30px;
   --title-size-m: 28px;
@@ -260,10 +261,19 @@ rect {
   justify-content: center;
 }
 
+.about__image {
+  position: fixed;
+  width: 88%;
+  height: 100vh;
+  opacity: 0.9;
+  transition: opacity 0.5s ease;
+}
+
 .about__intro {
   position: sticky;
   top: 20vh;
   left: 0;
+  width: 20%;
   height: 100vh;
   display: flex;
   flex-direction: column;
@@ -280,7 +290,7 @@ rect {
 
 .about__title {
   opacity: 1;
-  font-size: var(--title-size-xl);
+  font-size: var(--title-size-xxl);
   width: 100%;
   text-align: center;
   height: 1.5em;
@@ -293,29 +303,104 @@ rect {
   transform: translateX(0);
 }
 
-.about__nav {
+.about__nav,
+.about__nav-hide {
+  position: relative;
   width: 100%;
+  height: 2.5em;
   margin-top: 1em;
   padding: 12px 0;
-  background-color: rgba(0, 0, 0, 0.63);
   font-size: var(--font-size-l);
-  border: 2px solid var(--pale-white);
-  border-radius: var(--border-radius-s);
-  color: var(--primary-color);
   outline: none;
-  transition: background-color 0.4s, border-width 0.4s, top 0.4s, color 0.4s,
-    opacity 0.4s;
-  animation-iteration-count: infinite;
+  background-color: transparent;
 }
 
-.about__nav:not(.focus),
-.about__nav:not(:hover) {
-  animation: flash 2s ease;
+.about__nav {
+  color: transparent;
+}
+
+.about__nav-hide {
+  color: var(--primary-color);
+}
+
+.about__nav::before,
+.about__nav-hide::before {
+  content: "";
+  position: absolute;
+  top: 0px;
+  left: 0px;
+  background-color: rgba(0, 0, 0, 0.63);
+  width: calc(100% + -2px);
+  height: calc(100% + -2px);
+  border: 2px solid var(--pale-white);
+  border-radius: var(--border-radius-s);
+  animation-duration: 0.3s;
+  animation-fill-mode: forwards;
+}
+
+.about__nav::before {
+  transform: translateX(-100vw);
+  animation-name: slideBorder;
+}
+
+.about__nav-hide::before {
+  animation-name: slideBorder-hide;
+  animation-delay: 0.2s;
+}
+
+@keyframes slideBorder {
+  to {
+    transform: translateX(0);
+  }
+}
+
+@keyframes slideBorder-hide {
+  to {
+    transform: translateX(-100vw);
+  }
+}
+
+.about__nav::after,
+.about__nav-hide::after {
+  content: attr(data-text);
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 100%;
+  font-weight: bold;
+  color: var(--primary-color);
+  animation-duration: 0.3s;
+  animation-fill-mode: forwards;
+}
+
+.about__nav::after {
+  transform: translate(100vw, -50%);
+  animation-name: slideText;
+  animation-delay: 0.2s;
+}
+
+.about__nav-hide::after {
+  transform: translate(-50%, -50%);
+  animation-name: slideText-hide;
+  animation-delay: 0.4s;
+}
+
+@keyframes slideText {
+  to {
+    transform: translate(-50%, -50%);
+  }
+}
+
+@keyframes slideText-hide {
+  to {
+    transform: translate(50vw, -50%);
+  }
 }
 
 .about__nav.focus,
 .about__nav:hover {
   animation: pulse 0.3s ease-in-out;
+  background-color: black;
 }
 
 .about__guide {
@@ -329,56 +414,16 @@ rect {
   background-color: rgba(0, 0, 0, 0.63);
   width: 100%;
   opacity: 1;
-  transition: background-color 0.5s, width 0.4s, border-width 0.4s, padding 0.4s;
+  transition: background-color 0.4s, width 0.4s, border-width 0.4s, padding 0.4s;
 }
 
 .about__guide p:first-child {
   margin-top: 1em;
+  word-break: keep-all;
 }
 
 .about__guide p:last-child {
   margin-bottom: 1em;
-}
-
-@keyframes flash {
-  0% {
-    opacity: 0;
-  }
-
-  50% {
-    opacity: 1;
-  }
-  100% {
-    opacity: 0;
-  }
-}
-
-#project {
-  transition: opacity 1s, transform 1s;
-  opacity: 1;
-  transform: translateX(0);
-}
-
-#project.hide {
-  opacity: 0;
-  transform: translateX(-106%);
-}
-
-.about__image {
-  position: fixed;
-  width: 88%;
-  height: 100vh;
-  opacity: 0.9;
-  transition: opacity 0.5s ease;
-}
-
-.project-header {
-  opacity: 0;
-  transition: opacity 0.5s ease-in-out;
-}
-
-.project-header.show {
-  opacity: 1;
 }
 
 @keyframes extend-seperator {
@@ -747,6 +792,14 @@ rect {
 #project {
   width: 100%;
   height: calc(100vh - 60px);
+  transition: opacity 1s, transform 1s;
+  opacity: 1;
+  transform: translateX(0);
+}
+
+#project.hide {
+  opacity: 0;
+  transform: translateX(-106%);
 }
 
 .project-header {
@@ -755,6 +808,7 @@ rect {
   justify-content: center;
   padding: 20px 0;
   height: 18%;
+  transition: opacity 0.5s ease-in-out;
 }
 
 .project-header__box {
@@ -806,7 +860,7 @@ rect {
 
 .project-content__selection__title,
 .project-content__selection__item {
-  color: var(--text-color);
+  color: var(--pale-white);
   transition: color 0.45s ease-in;
 }
 
@@ -1151,27 +1205,16 @@ rect {
 /*? 푸터  */
 
 footer {
+  position: relative;
   background-color: var(--bg-color);
   display: flex;
   justify-content: space-between;
   color: var(--text-color);
   margin-top: 20px;
   margin-bottom: 20px;
-  bottom: 0;
-  left: 0;
+  height: 80px;
   width: 100%;
   transition: background-color 0.45s ease-in, color 0.45s ease-in;
-}
-
-.scrolling-character {
-  width: 40px;
-  height: 40px;
-  background-image: url("/public/img/moon.webp");
-  background-size: contain;
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  animation: scrolling 10s linear infinite;
 }
 
 .copyright {
@@ -1194,15 +1237,6 @@ footer {
 
 .copyright sup {
   transform: translateY(2px);
-}
-
-@keyframes scrolling {
-  0% {
-    left: -50px;
-  }
-  100% {
-    left: calc(100% + 50px);
-  }
 }
 
 /*? 초기 이미지 */

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -119,11 +119,11 @@ rect {
 }
 
 .header__logo path {
-  fill: var(--text-color);
+  fill: var(--pale-white);
 }
 
 .header__logo rect {
-  stroke: var(--text-color);
+  stroke: var(--pale-white);
 }
 
 .header__logo.focus path,
@@ -255,7 +255,7 @@ rect {
   position: relative;
   background-color: var(--bg-color);
   color: var(--pale-white);
-  height: 180vh;
+  height: 200vh;
   display: flex;
   justify-content: center;
 }
@@ -303,26 +303,19 @@ rect {
   border-radius: var(--border-radius-s);
   color: var(--primary-color);
   outline: none;
-  position: absolute;
-  top: 44%;
-  left: 0;
   transition: background-color 0.4s, border-width 0.4s, top 0.4s, color 0.4s,
     opacity 0.4s;
+  animation-iteration-count: infinite;
 }
 
 .about__nav:not(.focus),
 .about__nav:not(:hover) {
-  animation: flash 2s ease infinite;
+  animation: flash 2s ease;
 }
 
 .about__nav.focus,
 .about__nav:hover {
   animation: pulse 0.3s ease-in-out;
-}
-
-.about__nav.fix {
-  position: fixed;
-  animation: none;
 }
 
 .about__guide {
@@ -796,7 +789,7 @@ rect {
   transition: background-color 0.45s ease-in;
   width: 100%;
   height: 70%;
-  /* background-image: url("/public/img/about-2.png"); */
+  background-image: url("/public/img/about-2.png");
   background-size: cover;
 }
 
@@ -1108,6 +1101,11 @@ rect {
 
 /*? contact */
 
+#contact {
+  margin-left: auto;
+  margin-right: auto;
+}
+
 #contact h2 {
   text-align: center;
   font-size: var(--title-size-l);
@@ -1177,7 +1175,6 @@ footer {
 }
 
 .copyright {
-  /* position: absolute; */
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/handlers/section-scroller.js
+++ b/src/handlers/section-scroller.js
@@ -4,19 +4,15 @@ import { addFocus } from "./focus-handler.js";
 
 const calcCenterPositionOfSection = (section) => {
   const windowHeight = window.innerHeight;
-  const headerHeight = document.querySelector("header").offsetHeight;
   const sectionTop = section.offsetTop;
   const sectionHeight = section.offsetHeight;
-  const position =
-    sectionTop - (windowHeight - sectionHeight) / 2 + headerHeight / 2;
+  const position = sectionTop - (windowHeight - sectionHeight) / 2;
   return position;
 };
 
 const about = document.getElementById("about");
 const project = document.getElementById("project");
-const contact = document.getElementById("contact");
 const PROJECT_POSITION = calcCenterPositionOfSection(project);
-const CONTACT_POSITION = calcCenterPositionOfSection(contact);
 const focusOnFirstItem = (section) => {
   addFocus(section.querySelector(".focusable"));
 };
@@ -24,20 +20,13 @@ const focusOnFirstItem = (section) => {
 const scrollToSection = (sectionId, isEnter) => {
   switch (sectionId) {
     case "about":
+    case "home":
       scrollTo(0, 0);
       isEnter && focusOnFirstItem(about);
       break;
     case "project":
       scrollTo(0, PROJECT_POSITION);
       isEnter && focusOnFirstItem(project);
-      break;
-    case "contact":
-      scrollTo(0, CONTACT_POSITION);
-      isEnter && focusOnFirstItem(contact);
-      break;
-    case "home":
-      scrollTo(0, 0);
-      isEnter && focusOnFirstItem(about);
       break;
     default:
       break;

--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,6 @@ window.addEventListener("load", () => {
   const START_Y_OF_GUIDE =
     START_Y_OF_TITLE_AND_CANVAS + HEIGHT_OF_ABOUT * (1 / 8);
   const START_Y_OF_BACKGROUND = 168 + START_Y_OF_GUIDE;
-  const START_Y_OF_NAV = HEIGHT_OF_ABOUT / 2.4;
 
   addClickAndEnterHandler(settingButton)(() => {
     themeBtn.classList.toggle("focusable");
@@ -47,7 +46,7 @@ window.addEventListener("load", () => {
   scrollytellingTitleAndCanvas(START_Y_OF_TITLE_AND_CANVAS, HEIGHT_OF_ABOUT);
   scrollytellingAboutGuide(START_Y_OF_GUIDE);
   scrollytellingBackgroundImage(START_Y_OF_BACKGROUND);
-  scrollytellingAboutNavAndProject(START_Y_OF_NAV);
+  scrollytellingAboutNavAndProject();
   handleTabsFocusAndHover();
   setupMuteButton(setupSound);
   setupThemeButton();

--- a/src/project/Selection.js
+++ b/src/project/Selection.js
@@ -48,6 +48,8 @@ const createProjectFigure = () => {
   });
   const projectImg = createElement("img", {
     class: "project-content__overview__image",
+    src: "",
+    alt: "",
   });
   const projectSkill = createElement("ul", {
     class: "project-content__overview__skill",

--- a/src/ui/move-text-onmouse.js
+++ b/src/ui/move-text-onmouse.js
@@ -1,18 +1,20 @@
 const moveTextOnMouse = (textElement) => {
   function translateTitle(e) {
-    const { offsetX: x, offsetY: y } = e,
-      { offsetWidth: width, offsetHeight: height } = e.target,
-      move = 12,
-      xMove = (x / width) * (move * 8) - move * 4,
-      yMove = (y / height) * (move * 2) - move;
+    const { offsetX, offsetY, target } = e;
+    const { offsetWidth, offsetHeight } = target;
+    const move = 12;
+    const xMove = (offsetX / offsetWidth) * (move * 8) - move * 4;
+    const yMove = (offsetY / offsetHeight) * (move * 2) - move;
 
     e.target.style.transform = `translate(${xMove}px, ${yMove}px)`;
+  }
 
-    if (e.type === "mouseleave") e.target.style.transform = "";
+  function reset(e) {
+    e.target.style.transform = "";
   }
 
   textElement.addEventListener("mousemove", translateTitle);
-  textElement.addEventListener("mouseleave", translateTitle);
+  textElement.addEventListener("mouseleave", reset);
 };
 
 export default moveTextOnMouse;

--- a/src/ui/scrollytelling-about-nav-and-project.js
+++ b/src/ui/scrollytelling-about-nav-and-project.js
@@ -1,58 +1,43 @@
-const scrollytellingAboutNavAndProject = async (START_Y_OF_NAV) => {
-  setTimeout(() => {
-    const aboutNav = document.querySelector(".about__nav");
-    const project = document.querySelector("#project");
-    const aboutWidth = aboutNav.getBoundingClientRect().width;
-    const aboutLeft = aboutNav.getBoundingClientRect().left;
-    let isFixed = false;
-
-    function reset() {
-      isFixed = false;
-      aboutNav.classList.remove("fix");
-      aboutNav.style.opacity = "";
-      aboutNav.style.width = "100%";
-      aboutNav.style.left = "0";
-      aboutNav.style.backgroundColor = `rgba(0, 0, 0, 0.63)`;
-      aboutNav.style.borderColor = "var(--pale-white)";
-      aboutNav.style.color = "var(--primary-color)";
-      aboutNav.textContent = "See Work";
+const scrollytellingAboutNavAndProject = () => {
+  const aboutNav = document.querySelector(".about__nav");
+  const project = document.querySelector("#project");
+  const aboutGuide = document.querySelector(".about__guide");
+  let isHide = false;
+  const inersectionCallback = ([entry]) => {
+    if (entry.isIntersecting) {
+      project.classList.add("hide");
+    } else {
+      project.classList.remove("hide");
     }
+  };
+  const intersectionObserver = new IntersectionObserver(inersectionCallback, {
+    rootMargin: "200px 0px",
+  });
 
-    const observer = new IntersectionObserver((entries) => {
-      entries.forEach((entry) => {
-        if (entry.isIntersecting) {
-          project.classList.add("hide");
-        } else {
-          project.classList.remove("hide");
+  const mutationObserver = new MutationObserver((mutationList) => {
+    mutationList.map(async (entry) => {
+      if (entry.type === "attributes" && entry.attributeName === "style") {
+        const currentWidth = entry.target.style.width;
+        if (currentWidth === "0px" && !isHide) {
+          isHide = true;
+          aboutNav.classList.remove("about__nav");
+          aboutNav.classList.add("about__nav-hide");
+          return;
         }
-      });
-    });
-
-    observer.observe(aboutNav);
-
-    window.addEventListener("scroll", () => {
-      const scrollValue = scrollY - START_Y_OF_NAV;
-      if (scrollValue >= 0 && scrollValue < 600) {
-        if (!isFixed) {
-          aboutNav.style.width = `${aboutWidth}px`;
-          aboutNav.classList.add("fix");
-          aboutNav.style.left = `${aboutLeft}px`;
-          isFixed = true;
+        if (currentWidth !== "0px" && isHide) {
+          aboutNav.classList.remove("about__nav-hide");
+          aboutNav.classList.add("about__nav");
+          isHide = false;
         }
-        if (scrollValue >= 200) {
-          aboutNav.style.borderColor = "transparent";
-        }
-        if (scrollValue >= 400) {
-          aboutNav.style.backgroundColor = "transparent";
-          aboutNav.style.color = "var(--text-color)";
-          aboutNav.textContent = "Thank you!";
-        }
-        aboutNav.style.opacity = 2 - scrollValue / 600;
-      } else {
-        reset();
       }
     });
-  }, 300);
+  });
+
+  mutationObserver.observe(aboutGuide, {
+    attributes: true,
+    attributeFilter: ["style"],
+  });
+  intersectionObserver.observe(aboutNav);
 };
 
 export default scrollytellingAboutNavAndProject;

--- a/src/ui/scrollytelling-background-image.js
+++ b/src/ui/scrollytelling-background-image.js
@@ -1,13 +1,16 @@
+import throttle from "../utils/throttle.js";
+
 const scrollytellingBackgroundImage = (START_Y_OF_BACKGROUND) => {
   const backgroundImage = document.querySelector(".about__image");
   const aboutHeight = document.getElementById("about").offsetHeight;
-  window.addEventListener("scroll", () => {
+  const scrollytelling = throttle(() => {
     if (scrollY <= START_Y_OF_BACKGROUND + 30) {
       backgroundImage.style.opacity = "0.9";
     } else {
       backgroundImage.style.opacity = 1 - (scrollY / aboutHeight) * 2.5;
     }
-  });
+  }, 100);
+  window.addEventListener("scroll", scrollytelling);
 };
 
 export default scrollytellingBackgroundImage;

--- a/src/ui/scrollytelling-background-image.js
+++ b/src/ui/scrollytelling-background-image.js
@@ -7,7 +7,7 @@ const scrollytellingBackgroundImage = (START_Y_OF_BACKGROUND) => {
     if (scrollY <= START_Y_OF_BACKGROUND + 30) {
       backgroundImage.style.opacity = "0.9";
     } else {
-      backgroundImage.style.opacity = 1 - (scrollY / aboutHeight) * 2.5;
+      backgroundImage.style.opacity = 1 - (scrollY / aboutHeight) * 3;
     }
   }, 100);
   window.addEventListener("scroll", scrollytelling);

--- a/src/ui/scrollytelling-loading-bar.js
+++ b/src/ui/scrollytelling-loading-bar.js
@@ -1,13 +1,17 @@
+import throttle from "../utils/throttle.js";
+
 const scrollytellingLoadingBar = () => {
   const loadingBar = document.querySelector(".loading-bar");
   const documentHeight = document.body.clientHeight;
-  window.addEventListener("scroll", () => {
+
+  const scrollytelling = throttle(() => {
     const width = Math.min(
       (scrollY / (documentHeight - innerHeight)) * 100,
       100
     );
     loadingBar.style.width = `${width}%`;
-  });
+  }, 100);
+  window.addEventListener("scroll", scrollytelling);
 };
 
 export default scrollytellingLoadingBar;

--- a/src/ui/sub-title/Effect.js
+++ b/src/ui/sub-title/Effect.js
@@ -11,11 +11,11 @@ class Effect {
     this.MAX_TEXT_WIDTH = canvasWidth * 0.8;
     this.verticalOffset = 0;
     this.particles = [];
-    this.gap = 1;
+    this.gap = 2;
     this.mouse = {
-      radius: 1600,
-      x: 0,
-      y: 0,
+      radius: 2000,
+      x: 10000,
+      y: 10000,
     };
   }
 

--- a/src/ui/sub-title/Effect.js
+++ b/src/ui/sub-title/Effect.js
@@ -6,7 +6,7 @@ class Effect {
     this.canvasHeight = canvasHeight;
     this.textX = this.canvasWidth / 2;
     this.textY = this.canvasHeight / 2;
-    this.fontSize = 36;
+    this.fontSize = 40;
     this.lineHeight = this.fontSize * 1.1;
     this.MAX_TEXT_WIDTH = canvasWidth * 0.8;
     this.verticalOffset = 0;

--- a/src/ui/sub-title/Particle.js
+++ b/src/ui/sub-title/Particle.js
@@ -1,12 +1,12 @@
 class Particle {
   constructor(effect, x, y, color) {
     this.effect = effect;
-    this.x = this.effect.canvasWidth;
-    this.y = this.effect.canvasHeight;
+    this.x = effect.canvasWidth;
+    this.y = effect.canvasHeight;
     this.color = color;
     this.originX = x;
     this.originY = y;
-    this.size = 2;
+    this.size = 3;
     this.dx = 0;
     this.dy = 0;
     this.vx = 0;

--- a/src/ui/sub-title/pixelAnimation.js
+++ b/src/ui/sub-title/pixelAnimation.js
@@ -12,7 +12,7 @@ window.addEventListener("load", () => {
   canvas.height = 120;
   const effect = new Effect(ctx, canvas.width, canvas.height, Particle);
   let timeoutId;
-  let isAnimating = false;
+  let isAnimating = true;
 
   const animate = () => {
     if (!isAnimating) return;
@@ -53,6 +53,9 @@ window.addEventListener("load", () => {
     }
   });
 
+  setTimeout(() => {
+    isAnimating = false;
+  }, 1000);
   effect.wrapText(TEXT);
   effect.render();
   updateCanvasPosition();

--- a/src/ui/sub-title/pixelAnimation.js
+++ b/src/ui/sub-title/pixelAnimation.js
@@ -1,5 +1,6 @@
 import Particle from "./Particle.js";
 import Effect from "./Effect.js";
+import debounce from "../../utils/debounce.js";
 
 window.addEventListener("load", () => {
   const canvas = document.getElementById("about__subtitle");
@@ -11,7 +12,7 @@ window.addEventListener("load", () => {
   canvas.height = 120;
   const effect = new Effect(ctx, canvas.width, canvas.height, Particle);
   let timeoutId;
-  let isAnimating = true;
+  let isAnimating = false;
 
   const animate = () => {
     if (!isAnimating) return;
@@ -20,23 +21,25 @@ window.addEventListener("load", () => {
     requestAnimationFrame(animate);
   };
 
-  const updateCanvasPosition = () => {
+  const updateCanvasPosition = debounce(() => {
     const canvasRect = canvas.getBoundingClientRect();
     effect.canvasX = canvasRect.left;
     effect.canvasY = canvasRect.top;
-  };
+  });
 
-  const handleMouseMove = (e) => {
-    const mouseX = e.clientX - effect.canvasX;
-    const mouseY = e.clientY - effect.canvasY;
+  // mouseoutOffset 매개변수는 mouseout 시 마우스 포인터를 완전히 분리시키기 위함
+  const handleMouseMove = ({ clientX, clientY }, mouseoutOffset = 0) => {
+    const mouseX = clientX - effect.canvasX - mouseoutOffset;
+    const mouseY = clientY - effect.canvasY - mouseoutOffset;
     effect.mouse.x = mouseX;
     effect.mouse.y = mouseY;
   };
 
-  window.addEventListener("mousemove", handleMouseMove);
   window.addEventListener("scroll", updateCanvasPosition);
   window.addEventListener("resize", updateCanvasPosition);
-  canvas.addEventListener("mouseout", () => {
+  canvas.addEventListener("mousemove", handleMouseMove);
+  canvas.addEventListener("mouseout", (e) => {
+    handleMouseMove(e, 10000);
     timeoutId = setTimeout(() => {
       isAnimating = false;
     }, 2000);

--- a/src/utils/debounce.js
+++ b/src/utils/debounce.js
@@ -1,0 +1,11 @@
+const debounce = (callback, delay = 400) => {
+  let timeoutId;
+  return (...args) => {
+    if (timeoutId) clearTimeout(timeoutId);
+    timeoutId = setTimeout(() => {
+      callback(...args);
+    }, delay);
+  };
+};
+
+export default debounce;

--- a/src/utils/throttle.js
+++ b/src/utils/throttle.js
@@ -1,0 +1,12 @@
+const throttle = (callback, delay = 400) => {
+  let timeoutId;
+  return (...args) => {
+    if (timeoutId) return;
+    timeoutId = setTimeout(() => {
+      callback(...args);
+      timeoutId = null;
+    }, delay);
+  };
+};
+
+export default throttle;


### PR DESCRIPTION
## 설명

- 스크롤 이벤트에 디바운스, 스로틀링 추가
- Frontend Developer 애니메이션 초기값을 true로 했다가 1초 뒤에 false로 하도록 변경  
기존엔 hover하기 전까지 계속 true였어서 낭비되고 있었음
- 일부 요소들의 스타일이 테마에 따라 안 보였으므로 테마 무관하게 잘 보이도록 스타일 변경
- 실제 마우스를 hover하기 전에 포인터 초기값이 캔버스의 0,0 좌표에 있어서 radius에 포함되기 때문에 애니메이션 작동했음
-> 포인터 초기값을 10000,10000으로 변경
- about__nav의 스크롤리텔링 추가
- 헤더가 fixed에서 absolute로 변경함에 따라 프로젝트 높이와 포지션 계산 로직에서 헤더 높이 빼도록 변경

## PR 유형

- [x] 🐛 버그 수정
- [x] ⚡ 기능 추가
- [x] 📢 개선

## Checklist:

- [x] 제목이 변경 사항을 잘 요약하도록 작성했습니다.
- [x] 컨벤션에 맞춰서 코드를 작성했습니다.
- [ ] 복잡한 코드에는 적절한 주석을 붙였습니다.
